### PR TITLE
fix(alert): remove manual RTL handling for text alignment

### DIFF
--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Pressable, StyleSheet, I18nManager } from 'react-native';
+import { Pressable, StyleSheet } from 'react-native';
 import {
   VariantProps,
   createRestyleComponent,
@@ -34,8 +34,6 @@ const AlertContainer = createRestyleComponent<
   Theme
 >([variantVariant], Box);
 
-const isRTL = I18nManager.isRTL;
-
 const Alert = ({
   variant = 'info',
   icon,
@@ -63,15 +61,13 @@ const Alert = ({
               variant="subtitle03Medium"
               pb="2xs"
               testID="alert-caption"
-              textAlign={isRTL ? 'left' : 'right'}>
+              textAlign={'left'}>
               {caption}
             </Text>
           ) : null}
 
           {description ? (
-            <Text
-              testID="alert-description"
-              textAlign={isRTL ? 'left' : 'right'}>
+            <Text testID="alert-description" textAlign={'left'}>
               {description}
             </Text>
           ) : null}

--- a/src/components/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/components/Alert/__snapshots__/Alert.test.tsx.snap
@@ -124,7 +124,7 @@ exports[`Alert should render alert correctly 1`] = `
               "fontWeight": "500",
               "lineHeight": 16,
               "paddingBottom": 8,
-              "textAlign": "right",
+              "textAlign": "left",
             },
           ]
         }
@@ -141,7 +141,7 @@ exports[`Alert should render alert correctly 1`] = `
               "color": "#273142",
               "fontFamily": "Rubik-Regular",
               "fontSize": 14,
-              "textAlign": "right",
+              "textAlign": "left",
             },
           ]
         }


### PR DESCRIPTION
Description:
This PR removes manual text alignment control using I18nManager.
React Native automatically handles text alignment based on the system language and layout direction (LTR/RTL). Since iOS and Android already adjust text alignment correctly for different languages, the extra logic was redundant.
Changes:
Removed explicit I18nManager checks for textAlign.
Set textAlign: 'left' as the default since React Native adjusts it automatically for RTL languages.
Why this fix?
Redundant logic removed: React Native's built-in text rendering already handles text alignment for different languages.
Simplifies the code: No need to manually check and override textAlign based on I18nManager.
Ensures consistency: Behavior is now fully aligned with React Native's native text rendering mechanisms.
