### PR TITLE
fix(Button): render children prop and add corresponding test

### DIFF
--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import theme from '../../theme';
 import { fireEvent, render } from '../../test-utils';
 import Button from './Button';
+import Text from '../Text/Text';
 import { ReactTestInstance } from 'react-test-renderer';
 
 describe('Button', () => {
@@ -190,5 +191,14 @@ describe('Button', () => {
 
     // then
     expect(buttonComponent.props.alignSelf).toBe('stretch');
+  });
+
+  test('should render custom children correctly', () => {
+    const { getByText } = render(
+      <Button testID="button">
+        <Text>Custom Content</Text>
+      </Button>,
+    );
+    expect(getByText('Custom Content')).toBeTruthy();
   });
 });

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -192,6 +192,7 @@ const Button = ({
         {...variantColors}>
         {iconView}
         {labelView}
+        {children}
       </ButtonContainer>
     </PressableContainer>
   );


### PR DESCRIPTION
- Added support for rendering the `children` prop inside ButtonContainer
- Allows usage of fully custom content inside <Button> (e.g. badge, icon+text combos)
- Added a test to verify that `children` content is rendered correctly